### PR TITLE
fix: persist SAF URI permissions for queued upload sources

### DIFF
--- a/app/src/main/java/de/schliweb/sambalite/ui/controllers/ActivityResultController.java
+++ b/app/src/main/java/de/schliweb/sambalite/ui/controllers/ActivityResultController.java
@@ -171,9 +171,36 @@ public class ActivityResultController {
     // Clean up UI state first
     inputController.hideKeyboardAndClearFocus();
 
+    // Keep read access after the app process stops. The transfer queue can start this
+    // upload much later, when the temporary permission from the file picker is not available.
+    persistUploadReadPermission(uri, "upload source file");
+
     // Delegate to the file operation callback
     if (fileOperationCallback != null) {
       fileOperationCallback.onFileUploadResult(uri);
+    }
+  }
+
+  /**
+   * Takes a persistable read permission for a selected upload source. {@code TransferWorker} can
+   * then open the URI after the app process stops and starts again.
+   *
+   * <p>Some content providers do not give persistable permissions. The method thus catches the
+   * exception and writes a log message. The upload then has the same behavior as before: it is
+   * successful while the app process continues to run.
+   *
+   * @param uri The URI of the selected file or folder
+   * @param sourceType The type of the source, for the log message
+   */
+  private void persistUploadReadPermission(@NonNull Uri uri, @NonNull String sourceType) {
+    try {
+      activity
+          .getContentResolver()
+          .takePersistableUriPermission(uri, Intent.FLAG_GRANT_READ_URI_PERMISSION);
+    } catch (Exception e) {
+      LogUtils.w(
+          "ActivityResultController",
+          "takePersistableUriPermission failed for " + sourceType + ": " + e.getMessage());
     }
   }
 
@@ -253,6 +280,10 @@ public class ActivityResultController {
   private void handlePickFolderResult(Uri uri) {
     // Clean up UI state first
     inputController.hideKeyboardAndClearFocus();
+
+    // Keep read access to the folder. The queued uploads of the child documents use this
+    // permission, thus they fail after an app restart if the permission is not persistable.
+    persistUploadReadPermission(uri, "upload source folder");
 
     // Delegate to the file operation callback
     if (fileOperationCallback != null) {
@@ -348,6 +379,10 @@ public class ActivityResultController {
     intent.addCategory(Intent.CATEGORY_OPENABLE);
     intent.setType("*/*"); // Allow any file type
     intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true);
+    // Request a persistable permission, because the transfer queue can start the
+    // upload after the app process stops and starts again
+    intent.addFlags(
+        Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
     LogUtils.d("ActivityResultController", "Starting file picker activity for upload");
     pickFileLauncher.launch(intent);
   }
@@ -356,6 +391,10 @@ public class ActivityResultController {
   public void selectFolderToUpload() {
     LogUtils.d("ActivityResultController", "Selecting folder for folder contents upload");
     Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+    // Request a persistable permission, because the transfer queue can start the
+    // uploads of the child documents after the app process stops and starts again
+    intent.addFlags(
+        Intent.FLAG_GRANT_READ_URI_PERMISSION | Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
     pickFolderLauncher.launch(intent);
   }
 
@@ -411,6 +450,9 @@ public class ActivityResultController {
    */
   private void handleMultiplePickFileResult(@NonNull List<Uri> uris) {
     inputController.hideKeyboardAndClearFocus();
+    for (Uri uri : uris) {
+      persistUploadReadPermission(uri, "upload source file");
+    }
     if (fileOperationCallback != null) {
       fileOperationCallback.onMultipleFileUploadResult(uris);
     }


### PR DESCRIPTION
Fixes #33 

## Purpose

The details of the problem are in #33. TL;DR: queued uploads don't survive an app restart due to the app losing permission to access the selected files.

```
Permission Denial: reading com.android.externalstorage.ExternalStorageProvider uri
content://com.android.externalstorage.documents/tree/primary%3APictures%2Fimages/document/...
requires that you obtain access using ACTION_OPEN_DOCUMENT or related APIs
```

The net result is that the upload is permanently broken.

## Cause

The transfer queue keeps a content URI in the database, but for the upload code paths, this URI is not safe to persist. The download paths do this correctly. The upload paths do not do this:

- `selectFileToUpload()` creates an `ACTION_OPEN_DOCUMENT` intent without the persistable flag. `handlePickFileResult()` and `handleMultiplePickFileResult()` do not take a persistable permission.
- `selectFolderToUpload()` creates an `ACTION_OPEN_DOCUMENT_TREE` intent without permission flags. `handlePickFolderResult()` does not take a persistable permission. The child documents of this tree thus also lose the permission.

## Changes

- `selectFileToUpload()` and `selectFolderToUpload()` add `FLAG_GRANT_READ_URI_PERMISSION` and `FLAG_GRANT_PERSISTABLE_URI_PERMISSION` to the intent.
- `handlePickFileResult()`, `handleMultiplePickFileResult()`, and `handlePickFolderResult()` take a persistable read permission.

A new private method, `persistUploadReadPermission()`, contains this operation. The method logs exceptions and drops them, because some content providers do not give persistable permissions (and failing just means you experience the same behavior that exists today).

The download code paths require read and write permissions, but for upload we only need read permission for uploads.

## Tests

I've manually tested this on a Pixel 9 Pro with Android 16. 

## Notes

There's an edge case here. `MAX_PERSISTED_URI_GRANTS` on `UriGrantsManagerService` defines a limit of 512 persistable grants. If you manually select (i.e., through multi-file selection, not folder selection) 512 individual files, you'll exceed this limit and Android will silently release the oldest grants. If you select 600 files, none of them manage to fully upload, then the app restarts, the first 88 files that got requested will be stuck.

Technically this means that this PR isn't an exhaustive fix. But that's a pretty rare edge case, I think, since quite a few very specific things need to happen. And the forthcoming fix to #34 should prevent those files from blocking the queue.